### PR TITLE
Commented out logger used in debugging GameBoard

### DIFF
--- a/app/src/main/java/com/example/bikesh/checkerz/model/GameBoard.java
+++ b/app/src/main/java/com/example/bikesh/checkerz/model/GameBoard.java
@@ -95,8 +95,8 @@ public class GameBoard{
 
         if (x.color == PieceColor.RED) {
             redPieces.remove(x);
-            String s = Integer.toString(redPieces.size());
-            Log.d("ready", s);
+//            String s = Integer.toString(redPieces.size());
+//            Log.d("ready", s);
         }
         else {
             blackPieces.remove(x);


### PR DESCRIPTION
This fixes the error causing the GameBoard test suite to fail. I
believe the logger was being used for debugging purposes and is no
longer necessary. Commented out temporarily in preparation for later
removal.