### PR TITLE
Make Selected Piece More Obvious

### DIFF
--- a/app/src/main/java/com/example/bikesh/checkerz/viewmodel/CheckersViewModel.java
+++ b/app/src/main/java/com/example/bikesh/checkerz/viewmodel/CheckersViewModel.java
@@ -280,6 +280,8 @@ public class CheckersViewModel implements IViewModel {
         for (Position position : availableMovePositions) {
             availableMoves.replace("" + position.toString(), true);
         }
+        // Also highlights the selected piece to give better click feedback to the user
+        availableMoves.replace("" + selectedSquare.getPosition().toString(), true);
     }
 
 }


### PR DESCRIPTION
When a piece with no available moves was selected, there was no feedback
on in the view. Because of this it was hard for the user to tell what to
do if they selected a piece with no available moves and then tried to
select another piece before de-selecting their piece, the app would seem
unresponsive.

This commit highlights the selected piece which adds more meaingful
feedback for the user while clicking.

Closes #12