### PR TITLE
Make Restart Game logic Null-safe

### DIFF
--- a/app/src/main/java/com/example/bikesh/checkerz/viewmodel/CheckersViewModel.java
+++ b/app/src/main/java/com/example/bikesh/checkerz/viewmodel/CheckersViewModel.java
@@ -70,6 +70,8 @@ public class CheckersViewModel implements IViewModel {
         initializeTurnObservable();
         // Initialize the observable grid with the state of the Game's GameBoard
         syncGridAndAvailableMovesObservables();
+        updateBlackCapturesObservable(model.getBlackCaptures());
+        updateRedCapturesObservable(model.getRedCaptures());
 
         // TODO: If the black player is a bot, it should take its turn now
         IPlayer currentPlayer = model.getBlackPlayer();
@@ -82,19 +84,23 @@ public class CheckersViewModel implements IViewModel {
     }
 
     public void onRestartGameSelected() {
-        // Reset the state of the model
-        this.model.resetGame();
-        // Re-initialize the observables
-        initializeTurnObservable();
-        syncGridAndAvailableMovesObservables();
-
-        // TODO: If the black player is a bot, it should take its turn now
-        IPlayer currentPlayer = model.getBlackPlayer();
-        if (currentPlayer instanceof Bot) {
-            model.advanceTurn(currentPlayer.chooseMove(model.getCurrentState()));
+        if (this.model != null) {
+            // Reset the state of the model
+            this.model.resetGame();
+            // Re-initialize the observables
+            initializeTurnObservable();
             syncGridAndAvailableMovesObservables();
-            toggleTurnObservable();
             updateBlackCapturesObservable(model.getBlackCaptures());
+            updateRedCapturesObservable(model.getRedCaptures());
+
+            // TODO: If the black player is a bot, it should take its turn now
+            IPlayer currentPlayer = model.getBlackPlayer();
+            if (currentPlayer instanceof Bot) {
+                model.advanceTurn(currentPlayer.chooseMove(model.getCurrentState()));
+                syncGridAndAvailableMovesObservables();
+                toggleTurnObservable();
+                updateBlackCapturesObservable(model.getBlackCaptures());
+            }
         }
     }
 


### PR DESCRIPTION
Because the Restart game, assumed there was a game already in progress
when you clicked it, it did not perform check to see if the Model
existed before trying to clear it. This resulted in a NPE.

I moved all of the Restart game logic into if statement that checks
if the model is null.

I also added calls to update the Observables for captured pieces in both
the Restart game method and the New game method in the ViewModel.

Fixes #7 and fixes #15